### PR TITLE
Corrected broken ActiveSupport::LogSubscriber#color usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Corrected broken `ActiveSupport::LogSubscriber#color` usage (#29)
 
 ### 2.7.0 (10 February 2026)
 

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'price-hubble'
+require 'pricehubble'
 require 'pp'
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/bin/run
+++ b/bin/run
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'price-hubble'
+require 'pricehubble'
 require 'pp'
 
 $stdout.sync = true

--- a/lib/price_hubble/instrumentation/log_subscriber.rb
+++ b/lib/price_hubble/instrumentation/log_subscriber.rb
@@ -23,8 +23,6 @@ module PriceHubble
         log_response_details(event)
       end
 
-      private
-
       # Print some top-level request/action details.
       #
       # @param event [ActiveSupport::Notifications::Event] the subscribed event
@@ -82,7 +80,7 @@ module PriceHubble
       def req_origin(env)
         req = env.request.context
         action = req[:action]
-        action = color(action, color_method(action), true)
+        action = color(action, color_method(action), bold: true)
         client = req[:client].to_s.gsub('PriceHubble::Client', 'PriceHubble')
         "#{client.underscore}##{action}"
       end
@@ -93,7 +91,7 @@ module PriceHubble
       # @return [String] the request identifier
       def req_dest(env)
         method = env[:method].to_s.upcase
-        method = color(method, color_method(method), true)
+        method = color(method, color_method(method), bold: true)
         url = env[:url].to_s.gsub(/access_token=[^&]+/,
                                   'access_token=[FILTERED]')
         "#{method} #{url}"
@@ -104,10 +102,12 @@ module PriceHubble
       # @param env [Faraday::Env] the request/response environment
       # @return [String] the request identifier
       def res_result(env)
-        return color('no response', RED, true).to_s if env.response.nil?
+        return color('no response', RED, bold: true).to_s if env.response.nil?
 
         status = env[:status]
-        color("#{status}/#{env[:reason_phrase]}", color_status(status), true)
+        color("#{status}/#{env[:reason_phrase]}",
+              color_status(status),
+              bold: true)
       end
 
       # Decide which color to use for the given HTTP status code.

--- a/spec/price_hubble/instrumentation/log_subscriber_spec.rb
+++ b/spec/price_hubble/instrumentation/log_subscriber_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe PriceHubble::Instrumentation::LogSubscriber do
+  let(:instance) { described_class.new }
+  let(:event) do
+    instance_double(ActiveSupport::Notifications::Event,
+                    payload: env,
+                    duration: 10.44)
+  end
+  let(:env) { instance_double(Faraday::Env, response:, response_headers:) }
+  let(:response) { nil }
+  let(:response_headers) { {} }
+
+  before { PriceHubble.configuration.request_logging = true }
+
+  describe '#logger' do
+    let(:action) { instance.logger }
+
+    context 'when request logging is enabled' do
+      it 'returns configured logger' do
+        expect(action).to be_a(Logger)
+      end
+    end
+
+    context 'when request logging is disabled' do
+      before { PriceHubble.configuration.request_logging = false }
+
+      it 'returns nil' do
+        expect(action).to be_nil
+      end
+    end
+  end
+
+  describe '#request' do
+    let(:action) { instance.request(event) }
+
+    before do
+      allow(instance).to receive(:log_action_summary)
+      allow(instance).to receive(:log_request_details)
+      allow(instance).to receive(:log_response_details)
+    end
+
+    after { action }
+
+    it 'logs action summary' do
+      expect(instance).to receive(:log_action_summary).with(event)
+    end
+
+    it 'logs request details' do
+      expect(instance).to receive(:log_request_details).with(event)
+    end
+
+    it 'logs response details' do
+      expect(instance).to receive(:log_response_details).with(event)
+    end
+  end
+
+  describe '#log_action_summary' do
+    let(:action) { instance.log_action_summary(event) }
+
+    before do
+      allow(instance).to receive(:req_id).with(env).and_return('RID')
+      allow(instance).to receive(:req_origin).with(env).and_return('origin')
+      allow(instance).to receive(:res_result).with(env).and_return('200/OK')
+    end
+
+    it 'writes formatted info log line' do
+      expect { action }.to \
+        log_at_level(:info, '[RID] origin -> 200/OK (10.4ms)')
+    end
+  end
+
+  describe '#log_request_details' do
+    let(:action) { instance.log_request_details(event) }
+    let(:env) { instance_double(Faraday::Env, request_headers: headers) }
+    let(:headers) { { 'b' => '2', 'a' => '1' } }
+
+    before do
+      allow(instance).to receive(:req_id).with(env).and_return('RID')
+      allow(instance).to receive(:req_dest).with(env).and_return('DEST')
+    end
+
+    it 'writes formatted debug log line' do
+      action_json = headers.sort.to_h.to_json
+      expect { action }.to \
+        log_at_level(:debug, "[RID] DEST > #{action_json}")
+    end
+  end
+
+  describe '#log_response_details' do
+    before do
+      allow(instance).to receive(:req_id).with(env).and_return('RID')
+      allow(instance).to receive(:req_dest).with(env).and_return('DEST')
+      allow(instance).to receive(:res_result).with(env).and_return('RES')
+    end
+
+    context 'when response is nil' do
+      let(:action) { instance.log_response_details(event) }
+
+      it 'writes error log line' do
+        expect { action }.to log_at_level(:error, '[RID] DEST < RES')
+      end
+    end
+
+    context 'when response is present' do
+      let(:action) { instance.log_response_details(event) }
+      let(:response) { instance_double(Object) }
+      let(:response_headers) { { 'x' => '1', 'a' => '2' } }
+
+      it 'writes debug log line with headers' do
+        headers_json = response_headers.sort.to_h.to_json
+        expect { action }.to \
+          log_at_level(:debug, "[RID] DEST < #{headers_json}")
+      end
+    end
+  end
+
+  describe '#req_dest' do
+    let(:action) { instance.req_dest(env) }
+    let(:env) do
+      {
+        method: :get,
+        url: 'https://example.test?access_token=secret&x=1'
+      }
+    end
+
+    before do
+      allow(instance).to receive(:color_method).with('GET').and_return(:blue)
+      allow(instance).to receive(:color).and_return('GET')
+    end
+
+    it 'filters access token from url' do
+      expect(action).to include('access_token=[FILTERED]')
+    end
+  end
+
+  describe '#res_result' do
+    let(:action) { instance.res_result(env) }
+
+    context 'when response is nil' do
+      it 'returns colored no response text' do
+        expect(action).to eq("\e[1m\e[31mno response\e[0m")
+      end
+    end
+
+    context 'when response is present' do
+      let(:env) do
+        Faraday::Env.new(status: 200,
+                         reason_phrase: 'OK',
+                         response: instance_double(Object))
+      end
+
+      it 'returns colored status string' do
+        expect(action).to eq("\e[1m\e[32m200/OK\e[0m")
+      end
+    end
+  end
+end

--- a/spec/support/logging_matcher.rb
+++ b/spec/support/logging_matcher.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# A custom Ruby logger matcher. Use it like this:
+#
+#   expect { action }.to \
+#     log_at_level(:info, '[RID] origin -> 200/OK (11.4ms)')
+#
+# @param level [Symbol, String] the name of the log level (lowercase)
+# @param expected [String, Regexp] the expected string/regexp which was logged
+# @param logger [Logger] the logger object to use
+RSpec::Matchers.define(
+  :log_at_level
+) do |level, expected, logger: PriceHubble.logger|
+  supports_block_expectations
+
+  match do |expectation_block|
+    # A buffer to track all logger invocations (eg. +info+)
+    @calls = []
+
+    # Track all logger invocations for the given level
+    allow(logger).to receive(level) do |*args, &block|
+      message = block.call if block
+      message ||= args.first if args.any?
+      @calls << message if message
+    end
+
+    # Run the expectation block
+    expectation_block.call
+
+    # When no logger invocations where tracked, the match fails
+    next false if @calls.empty?
+
+    # Otherwise search for matching logger invocations, by their resulting log
+    # strings, comparing to the given expected string/regex
+    @matched_message = @calls.find do |msg|
+      case expected
+      when Regexp then msg =~ expected
+      else
+        msg == expected
+      end
+    end
+    !@matched_message.nil?
+  end
+
+  failure_message do
+    if @calls.empty?
+      "expected logger.#{level} to be called, but it was not"
+    else
+      res = @calls.map { |cur| "  - #{cur.inspect}" }.join("\n")
+      "expected a #{level} log matching #{expected.inspect}, got:\n#{res}"
+    end
+  end
+end


### PR DESCRIPTION
See: https://github.com/hausgold/hausgold-sdk/commit/f6437ba6302c4c0f284c58f0eda04ab788a52cf9#diff-c94465b9dcca61e50af46c67a78ebebcbe675cf4330d3e16931b36e2c42d538e

```diff
E, [2026-02-12T13:17:13.084643 #54] ERROR -- : Could not log "request.faraday" event. 
NoMethodError: undefined method `compact_blank' for true

"/app/vendor/bundle/ruby/3.3.0/gems/activesupport-8.1.2/lib/active_support/log_subscriber.rb:175:in `mode_from'",
"/app/vendor/bundle/ruby/3.3.0/gems/activesupport-8.1.2/lib/active_support/log_subscriber.rb:169:in `color'",
"/app/lib/price_hubble/instrumentation/log_subscriber.rb:85:in `req_origin'"

- action = color(action, color_method(action), true)
+ action = color(action, color_method(action), bold: true)
```