### PR TITLE
Corrected the Hash#deep_compact helper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### next
 
 * Corrected some RuboCop issues (#31)
+* Corrected the `Hash#deep_compact` core extension behavior and added specs for
+  it (#32)
 
 ### 2.9.0 (18 February 2026)
 

--- a/Guardfile
+++ b/Guardfile
@@ -4,7 +4,7 @@
 # More info at https://github.com/guard/guard#readme
 
 ## Uncomment and set this to only include directories you want to watch
-(directories %w[lib spec]).select do |d|
+(directories %w[lib/price_hubble spec]).select do |d|
   if Dir.exist?(d)
     d
   else
@@ -35,10 +35,10 @@ guard :rspec, cmd: 'bundle exec rspec' do
   watch('spec/spec_helper.rb') { 'spec' }
   watch(%r{^lib/pricehubble.rb}) { 'spec' }
   watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/pricehubble/([^\\]+)\.rb$}) do |m|
-    "spec/pricehubble/#{m[1]}_spec.rb"
+  watch(%r{^lib/price_hubble/([^\\]+)\.rb$}) do |m|
+    "spec/price_hubble/#{m[1]}_spec.rb"
   end
-  watch(%r{^lib/pricehubble/([^\\]+)/(.*)\.rb$}) do |m|
+  watch(%r{^lib/price_hubble/([^\\]+)/(.*)\.rb$}) do |m|
     "spec/#{m[1]}/#{m[2]}_spec.rb"
   end
 end

--- a/lib/price_hubble/core_ext/hash.rb
+++ b/lib/price_hubble/core_ext/hash.rb
@@ -35,10 +35,9 @@ class Hash
   def deep_compact_in_object(object)
     case object
     when Hash
-      object = object.compact.transform_values do |value|
+      object.compact.transform_values do |value|
         deep_compact_in_object(value)
       end
-      object.empty? ? nil : object.compact
     when Array
       object.map { |item| deep_compact_in_object(item) }
     else

--- a/spec/price_hubble/core_ext/hash_spec.rb
+++ b/spec/price_hubble/core_ext/hash_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hash do
+  describe '#deep_compact' do
+    shared_examples 'deep_compact' do
+      let(:action) { input.deep_compact }
+
+      it 'does not modify in place' do
+        expect { action }.not_to change { input }
+      end
+
+      it 'returns a new hash' do
+        expect(action).not_to be(input)
+      end
+
+      it 'returns a new hash without nil-values in deep' do
+        expect(action).to match(output)
+      end
+    end
+
+    context 'with an empty hash' do
+      let(:input) { {} }
+      let(:output) { {} }
+
+      it_behaves_like 'deep_compact'
+    end
+
+    context 'with a deeply nested hash, which gets compacted' do
+      let(:input) { { a: { c: { e: nil }, d: nil }, b: nil } }
+      let(:output) { { a: { c: {} } } }
+
+      it_behaves_like 'deep_compact'
+    end
+
+    context 'with a deeply nested hash, keeping a single value' do
+      let(:input) { { a: { c: { e: true, f: nil }, d: nil }, b: nil } }
+      let(:output) { { a: { c: { e: true } } } }
+
+      it_behaves_like 'deep_compact'
+    end
+
+    context 'with a complex and deeply nested hash' do
+      let(:input) do
+        {
+          a: true,
+          b: '',
+          c: nil,
+          d: {
+            e: false,
+            f: nil,
+            g: {
+              h: nil,
+              i: 'test',
+              j: {
+                k: nil
+              }
+            },
+            l: [[[{ m: 1, n: nil, o: { p: :test, q: nil } }]]]
+          }
+        }
+      end
+      let(:output) do
+        {
+          a: true,
+          b: '',
+          d: {
+            e: false,
+            g: {
+              i: 'test',
+              j: {}
+            },
+            l: [[[{ m: 1, o: { p: :test } }]]]
+          }
+        }
+      end
+
+      it_behaves_like 'deep_compact'
+    end
+  end
+end


### PR DESCRIPTION
See: https://github.com/hausgold/hausgold-sdk/pull/272

---

Aligned the implementations, they differed in empty-hash-to-nil compaction. Now we leave empty hashes alone.